### PR TITLE
BaseRecyclerAdpter has to be opened to available inheritance

### DIFF
--- a/baserecycleradapter/src/main/java/com/gigigo/baserecycleradapter/adapter/BaseRecyclerAdapter.kt
+++ b/baserecycleradapter/src/main/java/com/gigigo/baserecycleradapter/adapter/BaseRecyclerAdapter.kt
@@ -13,7 +13,7 @@ import com.gigigo.baserecycleradapter.viewholder.OnItemDragListener
 import com.gigigo.baserecycleradapter.viewholder.OnItemLongClickListener
 import java.util.*
 
-class BaseRecyclerAdapter<Data : Any>(val viewHolderFactory: BaseViewHolderFactory) :
+open class BaseRecyclerAdapter<Data : Any>(val viewHolderFactory: BaseViewHolderFactory) :
     RecyclerView.Adapter<BaseViewHolder<Data>>() {
 
     val valueClassTypes = ArrayList<Class<*>>()


### PR DESCRIPTION
When we need to override BaseRecyclerAdpter behaviour, so need to open this class.